### PR TITLE
Adding Service Account permissions

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,4 +5,5 @@ gcloud projects add-iam-policy-binding $1 --member=serviceAccount:frame-prod@fra
 gcloud projects add-iam-policy-binding $1 --member=serviceAccount:frame-prod@frame-customer-iaas-prod.iam.gserviceaccount.com --role=roles/compute.securityAdmin
 gcloud projects add-iam-policy-binding $1 --member=serviceAccount:frame-prod@frame-customer-iaas-prod.iam.gserviceaccount.com --role=roles/compute.storageAdmin
 gcloud projects add-iam-policy-binding $1 --member=serviceAccount:frame-prod@frame-customer-iaas-prod.iam.gserviceaccount.com --role=roles/dns.admin
+gcloud projects add-iam-policy-binding $1 --member=serviceAccount:frame-prod@frame-customer-iaas-prod.iam.gserviceaccount.com --role=roles/iam.serviceAccountUser
 cd .. && rm -fR gcp-byo-cloud-shell-deployment


### PR DESCRIPTION
The Service Account User role (roles/iam.serviceAccountUser) lets a principal attach a service account to a resource. When the code running on that resource needs to authenticate, it can get credentials for the attached service account.